### PR TITLE
feat: Added new reactions

### DIFF
--- a/main.py
+++ b/main.py
@@ -233,9 +233,10 @@ async def on_message(message):
             'kitty': [custom_map["meow_heart"]],
             'meow': [custom_map["meow_heart"]],
             'sus': [custom_map["susblahaj"]],
-            'minecraft': [custom_map["video_game"]],
-            'hacktoberfest': [custom_map["jack_o_lantern"]],
-            'October': [custom_map["jack_o_lantern"]],        
+            'minecraft': [default_map["video_game"]],
+            'hacktoberfest': [default_map["jack_o_lantern"]],
+            'October': [default_map["jack_o_lantern"]],        
+            'congrats': [default_map["partying_face"], default_map["confetti_ball"], default_map["tada"]],
         }
 
         for substr, reacts in fun_reacts.items():

--- a/main.py
+++ b/main.py
@@ -233,6 +233,9 @@ async def on_message(message):
             'kitty': [custom_map["meow_heart"]],
             'meow': [custom_map["meow_heart"]],
             'sus': [custom_map["susblahaj"]],
+            'minecraft': [custom_map["video_game"]],
+            'hacktoberfest': [custom_map["jack_o_lantern"]],
+            'October': [custom_map["jack_o_lantern"]],        
         }
 
         for substr, reacts in fun_reacts.items():

--- a/main.py
+++ b/main.py
@@ -237,6 +237,7 @@ async def on_message(message):
             'hacktoberfest': [default_map["jack_o_lantern"]],
             'October': [default_map["jack_o_lantern"]],        
             'congrats': [default_map["partying_face"], default_map["confetti_ball"], default_map["tada"]],
+            'study' : [custom_map["studyblahaj"]],
         }
 
         for substr, reacts in fun_reacts.items():


### PR DESCRIPTION
## Here are the changes I made! I added reaction roles for the following.

### Hacktoberfest, October > 🎃
Whether Adam believes it or not, October is here, and it’s time for BlahajGang to get spooky, Adds a Jack-O-lantern to Hacktoberfest related messages and also when October is mentioned.

### Congrats > 🎊🎉🥳
Because BlahajGangers are winning so many hackathons and making other achievements, and congratulations messages are pouring into #shill yourself every few days, I added a congrats feature that enables PrideBot to react with the tada, confetti and party face emojis!

### Study > :studyblahaj:
BlahajGang is a community of mostly student developers, and with a lot of school stuff going on, pridebot will react to p every message which contains study with a :studyblahaj: emoji. I am 100 % sure that seeing a cute picture of blahaj studying will motivate students  of BlahajGang to start studying.

### Minecraft > 🎮
A really popular game on BlahajGang, which is why I added the video game reaction every time someone says Minecraft. 

## OKAY THANK YOU FOR READING THIS, NOW PLEASE APPROVE MY PR OR I WILL BLAHAJCRY.